### PR TITLE
added registration of named instances

### DIFF
--- a/src/main/java/org/jusecase/inject/Injector.java
+++ b/src/main/java/org/jusecase/inject/Injector.java
@@ -5,6 +5,8 @@ import net.jodah.typetools.TypeResolver;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
+import javax.naming.Name;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -98,7 +100,16 @@ public class Injector {
     }
 
     private void add(Class<?> clazz, Object implementationOrProvider) {
-        add(clazz, implementationOrProvider, implementations::put);
+        if (clazz.isAnnotationPresent((Named.class))) {
+            Named named = clazz.getAnnotation(Named.class);
+            if (named.value().isEmpty()) {
+                add(clazz, implementationOrProvider, implementations::put);
+            } else {
+                add(named.value(), clazz);
+            }
+        } else {
+            add(clazz, implementationOrProvider, implementations::put);
+        }
     }
 
     private void add(String name, Class<?> clazz, Object implementationOrProvider) {

--- a/src/test/java/org/jusecase/inject/ComponentTest.java
+++ b/src/test/java/org/jusecase/inject/ComponentTest.java
@@ -46,6 +46,9 @@ public interface ComponentTest {
         Injector.getInstance().reset();
     }
 
+    default void givenDependency(Class<?> clazz) {
+        Injector.getInstance().add(clazz);
+    }
     default void givenDependency(Object dependency) {
         Injector.getInstance().add(dependency);
     }

--- a/src/test/java/org/jusecase/inject/InjectorTest.java
+++ b/src/test/java/org/jusecase/inject/InjectorTest.java
@@ -138,6 +138,28 @@ public class InjectorTest implements ComponentTest {
     }
 
     @Test
+    void addBeanWithName() {
+        givenDependency(new TestDriverDb1());
+        givenDependency(new TestDriverDb2());
+        BeanWithNamedDependency bean = new BeanWithNamedDependency();
+
+        assertThat(bean.driver1).isNotSameAs(bean.driver2);
+    }
+
+    @Test
+    void addBeanWithNameAsClass() {
+        givenDependency(TestDriverDb1.class);
+        givenDependency(TestDriverDb2.class);
+
+        BeanWithNamedDependency bean = new BeanWithNamedDependency();
+
+        assertThat(bean.driver1).isNotNull();
+        assertThat(bean.driver2).isNotNull();
+        assertThat(bean.driver1).isNotSameAs(bean.driver2);
+    }
+
+
+    @Test
     void logger() {
         Injector.getInstance().addProvider(new LoggerProvider());
         LoggerUser1 loggerUser1 = new LoggerUser1();

--- a/src/test/java/org/jusecase/inject/classes/TestDriverDb1.java
+++ b/src/test/java/org/jusecase/inject/classes/TestDriverDb1.java
@@ -1,0 +1,10 @@
+package org.jusecase.inject.classes;
+
+import org.jusecase.inject.Component;
+
+import javax.inject.Named;
+
+@Component
+@Named("db1")
+public class TestDriverDb1 implements Driver {
+}

--- a/src/test/java/org/jusecase/inject/classes/TestDriverDb2.java
+++ b/src/test/java/org/jusecase/inject/classes/TestDriverDb2.java
@@ -1,0 +1,10 @@
+package org.jusecase.inject.classes;
+
+import org.jusecase.inject.Component;
+
+import javax.inject.Named;
+
+@Component
+@Named("db2")
+public class TestDriverDb2 implements Driver {
+}


### PR DESCRIPTION
Hi,

**Whats the issue?**
I have been trying to register some classes with `@Named` annotation and declaring them as dependencies in other places:

```java
@Component
@Named("someClass")
public class SomeClass implements SomeInterface {
}
```

**Expected Behavior**
`Injector.add(SomeClass.class)` or `Injector.add(new SomeClass())` should make the bean available for injecting with the corresponding `Named` property

**Current Behavior**
the bean is not registered with name provided by declared `Named` annotation

**Possible Solution**
Changing the `add` method from ...
```java
private void add(Class<?> clazz, Object implementationOrProvider) {
        add(clazz, implementationOrProvider, implementations::put);
    }
```
... to this one, which will check the class/instance for declared `Named` annoations:

```java
private void add(Class<?> clazz, Object implementationOrProvider) {
        if (clazz.isAnnotationPresent((Named.class))) {
            Named named = clazz.getAnnotation(Named.class);
            if (named.value().isEmpty()) {
                add(clazz, implementationOrProvider, implementations::put);
            } else {
                add(named.value(), clazz);
            }
        } else {
            add(clazz, implementationOrProvider, implementations::put);
        }
    }
```