### PR TITLE
upgraded aspectj version to 1.9.5 and fixing version conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ And AspectJ (for Java 11 we unfortunately can't use the official plugin):
 <plugin>
     <groupId>com.nickwongdev</groupId>
     <artifactId>aspectj-maven-plugin</artifactId>
-    <version>1.12.1</version>
+    <version>1.12.6</version>
     <configuration>
         <complianceLevel>${maven.compiler.release}</complianceLevel>
         <source>${maven.compiler.source}</source>
@@ -97,7 +97,7 @@ And AspectJ (for Java 11 we unfortunately can't use the official plugin):
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.4</version>
+            <version>1.9.5</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <junit.jupiter.version>5.0.0</junit.jupiter.version>
         <junit.platform.version>1.0.0</junit.platform.version>
+        <aspectj.version>1.9.5</aspectj.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.4</version>
+            <version>${aspectj.version}</version>
         </dependency>
 
         <dependency>
@@ -109,7 +110,7 @@
             <plugin>
                 <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.12.1</version>
+                <version>1.12.6</version>
                 <configuration>
                     <complianceLevel>11</complianceLevel>
                     <source>11</source>
@@ -133,7 +134,7 @@
                     <dependency>
                         <groupId>org.aspectj</groupId>
                         <artifactId>aspectjtools</artifactId>
-                        <version>1.9.4</version>
+                        <version>${aspectj.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Mixing AspectJ runtime/tools versions within your project will cause several issues, breaking your project without noticing it. 

Actual:
* `aspectj-maven-plugin` in version 1.12.1 comes with AspectJ version 1.9.2
* jusecase-inject and the readme examples were configured with version 1.9.4

With this pull request there should be no version conflicts as every dependency is now working with aspectj version 1.9.5.

Changes:
* upgraded `aspectj-maven-plugin` from version 1.12.1 to 1.12.6 -> comes with aspectj version 1.9.5
* upgraded jusecase-inject and the readme examples aspectj version from 1.9.4 to 1.9.5